### PR TITLE
Highlight clicked tile

### DIFF
--- a/Assets/Prefabs/Managers/PlayerManager.prefab
+++ b/Assets/Prefabs/Managers/PlayerManager.prefab
@@ -882,7 +882,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 1079
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Assets/Scripts/Managers/MapManager.cs
+++ b/Assets/Scripts/Managers/MapManager.cs
@@ -61,6 +61,13 @@ namespace TTT.Managers
 
         [SerializeField] public GameEvent _OnLastPlayerTurnEvent;
 
+        private LineRenderer lineRenderer;
+
+        void Start()
+        {
+            lineRenderer = GetComponent<LineRenderer>();
+        }
+
         public override void OnNetworkSpawn()
         {
             NetworkManager.Singleton.OnClientConnectedCallback += OnClientConnect;
@@ -168,10 +175,18 @@ namespace TTT.Managers
         {
             int index = GetCellIndexFromPosition(point);
             HexCell hc = HexCells[index];
-            hc.CellColor = newColor;
-            HexCells[index] = hc;
-
-            TriangulateHexMeshClientRpc(HexCells[index]);
+            Vector3[] corners = HexMath.GetHexCorners(HexSize, HexOrientation);
+            for (int i = 0; i < 6; i++)
+            {
+                lineRenderer.SetPosition(i, new Vector3(
+                    hc.CellPosition.x + corners[i].x,
+                    hc.CellPosition.y + 0.5f,
+                    hc.CellPosition.z + corners[i].z));
+            }
+            lineRenderer.SetPosition(6, new Vector3(
+                hc.CellPosition.x + corners[0].x,
+                hc.CellPosition.y + 0.5f,
+                hc.CellPosition.z + corners[0].z));
         }
 
         public void OnNewMap(UnityEngine.Object eventArgs)


### PR DESCRIPTION
remove tile changing colour to red when clicked
add line renderer to map manager
add line renderer outlining tile when tile is clicked

known gripe: the line renderer, depending on which tile clicked, will be hidden behind other tiles making it hard to tell where the selected tile is